### PR TITLE
Removed passing of 'iter' to 'spawnCorrelatorThreads'

### DIFF
--- a/RISC-V-correlator/main.cc
+++ b/RISC-V-correlator/main.cc
@@ -203,15 +203,15 @@ int main()
 	
 	spawnCorrelatorThreads(CORRELATOR_1X1, runCorrelator, samples, arraySize,
 			       visibilities, visArraySize, nrTimes, nrStations, nrChannels,
-			       nrThreads, iter, maxGflops, verbose, validateResults);
+			       nrThreads, maxGflops, verbose, validateResults);
 	
 	spawnCorrelatorThreads(CORRELATOR_2X1, runCorrelator, samples, arraySize,
 			       visibilities, visArraySize, nrTimes, nrStations, nrChannels,
-			       nrThreads, iter, maxGflops, verbose, validateResults);
+			       nrThreads, maxGflops, verbose, validateResults);
 	
 	spawnCorrelatorThreads(CORRELATOR_2X2, runCorrelator, samples, arraySize,
 			       visibilities, visArraySize, nrTimes, nrStations, nrChannels,
-			       nrThreads, iter, maxGflops, verbose, validateResults);
+			       nrThreads, maxGflops, verbose, validateResults);
     }
 
     endCommon();


### PR DESCRIPTION
The main in RISC-V-correlator incorrectly passes the amount of iterations when spawning correlator pthreads, which the function signature does not ask for.